### PR TITLE
replace dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ node.js scraper for NYC construction codes in PDF format
 
 This scraper reads in PDFs [published by the DOB](http://www.nyc.gov/html/dob/html/codes_and_reference_materials/2014_cons_codes_table_of_contents.shtml)
 
-The plan is to make the NYC construction codes exist online in an easy to use, searchable UI just like [dccode.org](http://www.dccode.org)
+The plan is to make the NYC construction codes exist online in an easy to use, searchable UI just like [chicagocode.org](http://chicagocode.org)
 
 This scraper sets up the following folder structure:
 


### PR DESCRIPTION
looks like dccode.org is gone. just popped in another example.
